### PR TITLE
Adjust read time calculations

### DIFF
--- a/src/js/hooks/useSurah.ts
+++ b/src/js/hooks/useSurah.ts
@@ -1,14 +1,14 @@
 import { useState, useEffect } from 'react';
-import { Quran } from 'lib/Quran';
+import { Quran, Locale } from 'lib/Quran';
 
-export default function (locale: string, surahId: number) {
+export default function (locale: Locale, surahId: number) {
   const [surah, setSurah] = useState(null);
 
   useEffect(() => {
     const path = `/${locale}/${surahId}/surah.json`;
     const text = document.querySelector<HTMLElement>(`script[src="${path}"]`).innerText;
     const json = JSON.parse(text);
-    setSurah(Quran.Surah.fromJSON(json.shift(), json));
+    setSurah(Quran.Surah.fromJSON(locale, json.shift(), json));
   }, []);
 
   return {

--- a/src/js/lib/Quran/Surah.ts
+++ b/src/js/lib/Quran/Surah.ts
@@ -1,3 +1,8 @@
+import { Locale } from "lib/Quran";
+import { DelayBaseLine, DelayPerWord } from "lib/i18n";
+
+export type Ayat = Ayah[];
+
 interface SurahDetails {
   id: string;
   place_of_revelation: string;
@@ -14,8 +19,6 @@ export interface Ayah {
   readTimeMs: number;
 }
 
-export type Ayat = Ayah[];
-
 interface IDObject {
   number: number,
   localeKey: string[]
@@ -25,17 +28,14 @@ export class Surah {
   #details: SurahDetails;
   ayat: Ayat;
 
-  static fromJSON(details: SurahDetails, ayat: Array<[number, string]>): Surah {
+  static fromJSON(locale: Locale, details: SurahDetails, ayat: Array<[number, string]>): Surah {
     return new Surah(
       details,
       ayat.map(([id, text]) => {
         return {
-          id: {
-            number: id,
-            localeKey: String(id).split("")
-          },
+          id: { number: id, localeKey: String(id).split("") },
           text,
-          readTimeMs: text.split(" ").length * 500,
+          readTimeMs: DelayBaseLine + (text.split(" ").length * DelayPerWord[locale]),
         };
       }),
     );

--- a/src/js/lib/i18n.ts
+++ b/src/js/lib/i18n.ts
@@ -32,6 +32,21 @@ const sTable: Record<Locale, Record<Strings, string>> = {
   }
 };
 
+/**
+ * The read time baseline - as a number milliseconds -
+ * that all Ayah share, regardless of locale.
+ */
+export const DelayBaseLine = 2000;
+
+/**
+ * The read time for each word in an Ayah,
+ * relative to the active locale.
+ */
+export const DelayPerWord: Record<Locale, number> = {
+  en: 500,
+  ar: 750
+};
+
 export function numbers (locale: Locale) {
   return function(keys: string | string[]): string {
     const table = nTable[locale];


### PR DESCRIPTION
A baseline of two seconds is introduced, and when
the Arabic locale is being used, each word has a
weight of 750ms rather than 500ms.