### PR TITLE
Prevent timer going out of sync when switching themes

### DIFF
--- a/src/js/components/TheQuran/Timer.tsx
+++ b/src/js/components/TheQuran/Timer.tsx
@@ -12,7 +12,7 @@ interface TimerProps {
 
 export function Timer ({ surah, ayah, stream, setStream, locale }: TimerProps) {
   const [ms, setMs] = useState(ayah.readTimeMs);
-  useEffect(() => setMs(ayah.readTimeMs), [ayah]);
+  useEffect(() => setMs(ayah.readTimeMs), [ayah.id]);
   useEffect(() => {
     if (stream.length === surah.ayat.length) {
       return;

--- a/src/js/pages/TheSurahPage.tsx
+++ b/src/js/pages/TheSurahPage.tsx
@@ -18,9 +18,9 @@ interface PageProps {
 function TheSurahPage({ locale, surahId, ayahId }: PageProps) {
   const path = `/${locale}/${surahId}/surah.json`;
   const node: HTMLScriptElement = document.querySelector(`script[src="${path}"]`);
-  const surah = Surah.fromDOMNode(locale, node);
   const [stream, setStream] = useState([]);
   const [theme, setTheme] = useState(getCookie("theme") || "moon");
+  const [surah] = useState<Surah>(Surah.fromDOMNode(locale, node));
   const readyToRender = stream.length > 0;
 
   useEffect(() => {


### PR DESCRIPTION
I discovered this bug while testing recent changes on iOS. 
After the theme was changed, there appeared to be two active 
threads of execution that would step on each other's toes.

Storing the surah with useState() appears to have fixed the bug.