### PR TITLE
Fix bug when "slice.coversOneAyah"

### DIFF
--- a/src/js/lib/Quran/slice.ts
+++ b/src/js/lib/Quran/slice.ts
@@ -4,6 +4,7 @@ export interface Slice {
   length: number
   coversOneAyah: boolean
   coversOneSurah: boolean
+  coversSubsetOfSurah: boolean
 }
 
 export function Slice(begin: number, end: number): Slice {
@@ -13,6 +14,7 @@ export function Slice(begin: number, end: number): Slice {
   self.end = end;
   self.coversOneAyah = begin === end;
   self.coversOneSurah = begin === 1 && end === 286;
+  self.coversSubsetOfSurah = begin >= 1 && end < 286;
   self.length = end - (begin - 1);
 
   return self;

--- a/src/js/pages/TheSurahPage.tsx
+++ b/src/js/pages/TheSurahPage.tsx
@@ -24,13 +24,12 @@ function TheSurahPage({ locale, surahId, slice }: Props) {
   const readyToRender = stream.length > 0;
   const surahName = locale === 'ar' ? surah.name : surah.translatedName;
   const endOfStream = (function() {
-    if (slice.coversOneSurah) {
+    if (slice.coversOneAyah || slice.coversOneSurah) {
       return stream.length === surah.ayat.length;
-    } else {
+    } else if (slice.coversSubsetOfSurah) {
       return stream.length === slice.length;
     }
   })();
-
 
   useEffect(() => {
     document.title = [


### PR DESCRIPTION
I discovered a bug where when the "ayah" parameter is 
set to a single ayah, and the end of the surah is reached - 
the "endOfStream" variable would continue to return false. 
This would lead to an error in the Timer component where 
"ayah" would be accessed as an undefined value.