### PR TITLE
Redirect to the surah index from the root path

### DIFF
--- a/rules/pages/RandomRedirect.rules
+++ b/rules/pages/RandomRedirect.rules
@@ -4,11 +4,6 @@
 # Contains rules that are related to RandomRedirect.html.erb
 # in one way or another
 
-compile "/html/RandomRedirect.html.erb" do
-  filter(:erb)
-  write("/index.html")
-end
-
 compile "/html/redirect-to-surah-slug.html.erb" do
   filter(:erb)
   1.upto(114) do |surahno|

--- a/rules/pages/TheSurahIndex.rules
+++ b/rules/pages/TheSurahIndex.rules
@@ -4,6 +4,16 @@
 # Contains rules that are related to TheSurahIndex in one
 # way or another.
 
+compile "/html/surah/index/redirect.html.erb" do
+  filter(:erb)
+  write("/index.html")
+end
+
+compile "/js/surah/index/redirect.ts" do
+  filter(:webpack)
+  write("/js/surah/index/redirect.js")
+end
+
 compile "/surahs.json" do
   write "/surahs.json"
 end

--- a/src/html/surah/index/redirect.html.erb
+++ b/src/html/surah/index/redirect.html.erb
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+  <head>
+    <title></title>
+  </head>
+  <body>
+    <script src="/js/surah/index/redirect.js"></script>
+  </body>
+</html>

--- a/src/js/surah/index/redirect.ts
+++ b/src/js/surah/index/redirect.ts
@@ -1,0 +1,6 @@
+import { Locale } from 'lib/Locale';
+
+(function(window, location) {
+  const locale = Locale(window).fromBrowser();
+  location.replace(`/${locale}/`);
+})(window, location);


### PR DESCRIPTION
#### Summary

When a browser visits the root path (/) then redirect 
to the surah index with the appropriate locale (eg /en/, /ar/).