### PR TITLE
Fix scroll jump

### DIFF
--- a/src/css/_layout.scss
+++ b/src/css/_layout.scss
@@ -67,7 +67,7 @@ body .root .content ul.body {
   list-style-type: none;
   height: 400px;
   padding: 0;
-  overflow: hidden;
+  scrollbar-gutter: stable both-edges;
 
   /* Height of 625px, or less */
   @media screen and (max-height: 625px) {
@@ -78,8 +78,4 @@ body .root .content ul.body {
   @media screen and (max-height: 595px) {
     height: 310px;
   }
-}
-
-body .root .content ul.body.scroll-y {
-  overflow-y: auto;
 }

--- a/src/css/pages/surah/stream.scss
+++ b/src/css/pages/surah/stream.scss
@@ -31,8 +31,8 @@
   }
 }
 
-.content ul.body.stream.scroll-y {
-  li.ayah p { width: 98%; }
+.content ul.body.stream {
+  li.ayah p { width: 99%; }
 }
 
 .content .timer {

--- a/src/js/components/Stream.tsx
+++ b/src/js/components/Stream.tsx
@@ -15,7 +15,11 @@ interface Props {
 }
 
 export function Stream({ surah, stream, locale, slice, endOfStream, isPaused, t }: Props) {
-  const className = classNames('body', 'stream', { 'scroll-y': endOfStream || isPaused });
+  const className = classNames('body', 'stream');
+  const style: React.CSSProperties = endOfStream || isPaused ?
+                                     { 'overflowY': 'auto' } :
+                                     { 'overflowY': 'hidden' };
+
   const ayat = stream.map((ayah: Quran.Ayah) => {
     return (
       <li key={ayah.id} className="ayah fade">
@@ -42,7 +46,7 @@ export function Stream({ surah, stream, locale, slice, endOfStream, isPaused, t 
   }, [stream]);
 
   return (
-    <ul lang={locale} className={className}>
+    <ul lang={locale} className={className} style={style}>
       {ayat}
     </ul>
   );


### PR DESCRIPTION
#### Summary

When the 'pause' button was clicked, the text could jump 
and become realigned according to the space taken by 
the now visible scrollbar.

This change fixes that issue by leaving a gap for the scrollbar 
whether it is visible or hidden.