### PR TITLE
Display eastern arabic numerals on Iridium / OpenBSD

### DIFF
--- a/src/js/lib/i18n.ts
+++ b/src/js/lib/i18n.ts
@@ -34,7 +34,10 @@ export function i18n(json: string): TFunction {
 }
 
 export function formatNumber(number: number, locale: Quran.Locale): string {
-  return number.toLocaleString(locale, { maximumFractionDigits: 1 })
+  const numLocale = locale === 'ar' ? 'ar-SA' : locale;
+  const options = { maximumFractionDigits: 1 };
+  return new Intl.NumberFormat(numLocale, options)
+               .format(number)
                .split(/([^\d])/)
                .join(' ');
 }


### PR DESCRIPTION
With Iridium running on OpenBSD, '1.toLocaleString("ar")' does not 
return an eastern arabic numeral. The more specific locale, "ar-SA", 
works as expected.