### PR TITLE
Add Nanoc::Filters::Tidy

### DIFF
--- a/.github/workflows/al-quran.yml
+++ b/.github/workflows/al-quran.yml
@@ -37,5 +37,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Prepare environment
       uses: './.github/actions/prepare-env'
+    - name: Add HTMLTidy
+      run: sudo apt-get install tidy
     - name: nanoc
       run: bundle exec rake build

--- a/README.md
+++ b/README.md
@@ -14,9 +14,14 @@ nginx, apache, etc).
   <strong>The stack</strong>
 </p>
 
+The following languages and tools have to be installed before
+the website can be built:
+
 * Ruby 3.1, or later.
 * NodeJS v18.15, or later.
-* TypeScript
+* [tidy-html5](https://github.com/htacg/tidy-html5) <br>
+  There is a good chance there's a package available for
+  tidy-html5 on your operating system of choice.
 
 <p align="left">
   <strong>Local development</strong>
@@ -27,7 +32,7 @@ __1. Clone__
     git clone https://github.com/ReflectsLight/al-quran.git
     cd al-quran
 
-__2. Install Ruby, and NodeJS packages__
+__2. Install Ruby, NodeJS packages__
 
     bundle install
     npm i

--- a/nanoc/lib/nanoc/filters/tidy.rb
+++ b/nanoc/lib/nanoc/filters/tidy.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class Nanoc::Filters::Tidy < Nanoc::Filter
+  require "fileutils"
+  include FileUtils
+  Error = Class.new(RuntimeError)
+
+  identifier :tidy
+  type text: :text
+
+  def self.default_options
+    @default_options ||= {wrap: 120, indent: true}
+  end
+
+  def run(content, options = {})
+    file = temporary_file_for(content)
+    tidy file, self.class.default_options.merge(options)
+  end
+
+  private
+
+  def tidy(file, options)
+    system "tidy", "-modify", "-quiet", *tidy_args(options), file.path
+    if $?.success?
+      File.read(file.path).tap { file.tap(&:unlink).close }
+    else
+      raise Error, "tidy exited unsuccessfully (exit code: #{$?.exitstatus})", []
+    end
+  end
+
+  def tidy_args(options)
+    options.each_with_object([]) do |(key, value), ary|
+      if value.equal?(true)
+        ary << "-#{key}"
+      else
+        ary.concat ["-#{key}", value.to_s]
+      end
+    end
+  end
+
+  def temporary_file_for(content)
+    dir = File.join(Dir.getwd, "tmp", "htmltidy")
+    mkdir_p(dir) unless Dir.exist?(dir)
+    file = Tempfile.new(File.basename(item.identifier.to_s), dir)
+    file.write(content)
+    file.tap(&:flush)
+  end
+end

--- a/nanoc/rules/pages/surah/index.rules
+++ b/nanoc/rules/pages/surah/index.rules
@@ -9,6 +9,7 @@ locales.each do |locale|
   compile "/html/pages/surah/index.html.erb", rep: "/#{locale}/surah/index" do
     context = Ryo.from(locale:)
     filter(:erb, locals: {context:})
+    filter(:tidy)
     write "/#{locale}/index.html"
   end
 end

--- a/nanoc/rules/pages/surah/stream.rules
+++ b/nanoc/rules/pages/surah/stream.rules
@@ -23,6 +23,7 @@ Ryo.each(slugs) do |id, slug|
       surah: {id:, name:, slug:}
     )
     filter(:erb, locals: {context:})
+    filter(:tidy)
     write "/#{locale}/#{identifier}/index.html"
   end
   locales.each do |locale|


### PR DESCRIPTION
Add a nanoc filter that runs HTML content through [tidy-html](https://github.com/htacg/tidy-html5).
The content that is first run through ERB is often indented 
incorrectly and inconsistently, and 'tidy' can fix that for us.