### PR TITLE
audio: import & improve useAudio (via EasyQuran) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ won't need to install these tools:
 
 ### Configuration
 
-**server.base_url** <br>
+**server.root_url** <br>
 If you plan to host the website on
 your own domain you should update
 [nanoc.yaml](nanoc.yaml.sample)
@@ -65,18 +65,18 @@ https://al-quran.reflectslight.io
 instead of using a relative path. For example
 [/src/sitemap.xml.erb](/src/sitemap.xml.erb)
 is one such place. Those links can be updated
-to your own domain by changing the `server.base_url`
+to your own domain by changing the `server.root_url`
 field in
 [nanoc.yaml](nanoc.yaml.sample)
 before running `bundle exec rake nanoc:build`.
 
-**audio.base_url** <br>
-`audio.base_url` controls what web server serves
+**audio.root_url** <br>
+`audio.root_url` controls what web server serves
 audio content.
 [The default](https://al-quran-audio.reflectslight.io/rifai)
 works out of the box. The URL for an audio file is
-resolved by joining `audio.base_url` and
-`/<surahid>/<ayahid>.mp3`. The `audio.base_url` option
+resolved by joining `audio.root_url` and
+`/<surahid>/<ayahid>.mp3`. The `audio.root_url` option
 makes it relatively easy to change the reciter
 at build time, before deploying the website.
 

--- a/etc/webpack.common.js
+++ b/etc/webpack.common.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const webpack = require("webpack");
 
 module.exports = {
   resolve: {
@@ -44,5 +45,11 @@ module.exports = {
       },
     ],
   },
-  plugins: [],
+  plugins: [
+    new webpack.DefinePlugin({
+      "buildenv": JSON.stringify(process.env.buildenv),
+      "audioUrl": JSON.stringify(process.env.audio_url),
+      "commitId": JSON.stringify(process.env.commit_id)
+    }),
+  ],
 };

--- a/nanoc.yaml.sample
+++ b/nanoc.yaml.sample
@@ -21,10 +21,10 @@ data_sources:
     layouts_dir: src/layouts
 
 audio:
-  base_url: https://al-quran-audio.reflectslight.io/rifai
+  root_url: https://al-quran-audio.reflectslight.io/rifai
 
 server:
-  base_url: https://al-quran.reflectslight.io
+  root_url: https://al-quran.reflectslight.io
   unix:
     path:
     mode: ug=rw,o=

--- a/nanoc/lib/utils.rb
+++ b/nanoc/lib/utils.rb
@@ -72,9 +72,9 @@ module Utils
   #
   # @return [String]
   #  Returns the base url for audio requests.
-  #  The default (https://al-quran.reflectslight.io/audio/alafasy)
+  #  The default (https://al-quran-audio.reflectslight.io/rifai)
   #  works out of the box.
-  def audio_base_url
+  def audio_url
     nanoc.audio.base_url
   end
 

--- a/nanoc/lib/utils.rb
+++ b/nanoc/lib/utils.rb
@@ -6,6 +6,8 @@
 # and Rakefile.rb all have access to the methods of this
 # module
 module Utils
+  extend self
+
   require "test-cmd"
   require_relative "utils/t"
   require_relative "utils/inline"
@@ -67,24 +69,24 @@ module Utils
 
   ##
   # The URL for an audio file is resolved
-  # by joining `nanoc.audio.base_url` and
-  # `/<surahid>/<ayahid>.mp3`.
+  # by joining `nanoc.audio.root_url` and
+  # `/<surahid>/<ayahid>.mp3`
   #
   # @return [String]
-  #  Returns the base url for audio requests.
+  #  Returns the root url for audio requests.
   #  The default (https://al-quran-audio.reflectslight.io/rifai)
-  #  works out of the box.
+  #  works out of the box
   def audio_url
-    nanoc.audio.base_url
+    nanoc.audio.root_url
   end
 
   ##
   # @return [String]
-  #  Returns the base URL for use with opengraph,
+  #  Returns the root URL for use with opengraph,
   #  <link> tags, /sitemap.xml, etc. The default is
-  #  https://al-quran.reflectslight.io.
-  def base_url
-    nanoc.server.base_url
+  #  https://al-quran.reflectslight.io
+  def root_url
+    nanoc.server.root_url
   end
 
   include T

--- a/rake/tasks/nanoc.rake
+++ b/rake/tasks/nanoc.rake
@@ -29,6 +29,8 @@ namespace :nanoc do
 
   task :setenv, %i[buildenv] do |t, args|
     ENV["SASS_PATH"] = File.join(dirs.content, "css")
+    ENV["audio_url"] = Utils.audio_url
+    ENV["commit_id"] = Utils.commit
     ENV["buildenv"] = args.buildenv || ENV["buildenv"] || "development"
   end
 end

--- a/share/al-quran.reflectslight.io/NEWS
+++ b/share/al-quran.reflectslight.io/NEWS
@@ -2,6 +2,20 @@
 
 * vNEXT
 
+**** Synchronize play|pause of stream with audio playback
+The play and pause buttons on the stream page were previously
+disconnected from the audio stream. That meant you could pause
+the stream, and still hear the audio. This change synchronizes
+the play and pause buttons with audio playback so that when the
+stream is paused, so is the audio
+
+**** Pull audio duration from MP3 file
+There was a bug in audio playback where the duration of an
+audio file was always pulled from ~durations.json~ instead
+of being pulled from the MP3 file. The fix for this bug saw
+an overhaul of the audio implementation with significant
+improvements to the audio player. Reported by [[https://github.com/farooqkz][@farooqkz]]
+
 **** Extend length of <title> tag
 The <title> tag now includes the "The Noble Quran" as text in
 addition to the name of the surah. This change was recommended

--- a/src/html/_opengraph.html.erb
+++ b/src/html/_opengraph.html.erb
@@ -2,22 +2,22 @@
   <meta property="og:type" content="article"/>
   <meta property="og:title" content="<%= t(context.locale, 'TheNobleQuran') %>"/>
   <meta property="og:description" content="<%= t(context.locale, 'meta.index.description') %>"/>
-  <meta property="og:url" content="<%= base_url %>/<%= context.locale %>/"/>
-  <meta property="og:image" content="<%= base_url %>/images/og/0.png?v=<%= commit %>"/>
+  <meta property="og:url" content="<%= root_url %>/<%= context.locale %>/"/>
+  <meta property="og:image" content="<%= root_url %>/images/og/0.png?v=<%= commit %>"/>
   <meta property="og:image:type" content="image/png"/>
 <% elsif file == "surah-stream.html.erb" %>
   <meta property="og:type" content="article"/>
   <meta property="og:title" content="<%= t(context.locale, 'TheNobleQuran') %>"/>
   <meta property="og:description" content="<%= context.surah.name %>"/>
-  <meta property="og:url" content="<%= base_url %>/<%= context.locale %>/<%= context.surah.urlName %>/"/>
-  <meta property="og:image" content="<%= base_url %>/images/og/<%= context.surah.id %>.png?v=<%= commit %>"/>
+  <meta property="og:url" content="<%= root_url %>/<%= context.locale %>/<%= context.surah.urlName %>/"/>
+  <meta property="og:image" content="<%= root_url %>/images/og/<%= context.surah.id %>.png?v=<%= commit %>"/>
   <meta property="og:image:type" content="image/png"/>
 <% elsif file == "random.html.erb" %>
   <meta property="og:type" content="article"/>
   <meta property="og:title" content="<%= t(context.locale, 'TheNobleQuran') %>"/>
   <meta property="og:description" content="<%= t(context.locale, 'meta.random.description') %>"/>
-  <meta property="og:url" content="<%= base_url %>/<%= context.locale %>/random/"/>
-  <meta property="og:image" content="<%= base_url %>/images/og/0.png?v=<%= commit %>"/>
+  <meta property="og:url" content="<%= root_url %>/<%= context.locale %>/random/"/>
+  <meta property="og:image" content="<%= root_url %>/images/og/0.png?v=<%= commit %>"/>
   <meta property="og:image:type" content="image/png"/>
 <% else %>
   <% error! "unknown file: #{file}" %>

--- a/src/html/main/random.html.erb
+++ b/src/html/main/random.html.erb
@@ -7,12 +7,12 @@
     <%= erb("_opengraph.html.erb", {file: "random.html.erb", context:}) %>
     <link
       rel="canonical"
-      href="<%= base_url %>/<%= context.locale %>/random/"
+      href="<%= root_url %>/<%= context.locale %>/random/"
     />
     <% context.locales.each do |locale| %>
     <link
       rel="alternate"
-      href="<%= base_url %>/<%= locale %>/random/"
+      href="<%= root_url %>/<%= locale %>/random/"
       hreflang="<%= locale %>" />
     <% end %>
     <%= erb("_favicon.html.erb") %>

--- a/src/html/main/redirect.html.erb
+++ b/src/html/main/redirect.html.erb
@@ -5,14 +5,14 @@
     <meta name="description" content="<%= t('en', 'meta.index.description') %>">
     <%= erb("_version.html.erb") %>
     <%= erb("_opengraph.html.erb", {file: "redirect.html.erb", context:}) %>
-    <% if nanoc.server.base_url == "https://al-quran.reflectslight.io" %>
+    <% if nanoc.server.root_url == "https://al-quran.reflectslight.io" %>
       <meta name="msvalidate.01" content="4459582FB69145E47726C07F773450A9">
     <% end %>
-    <link rel="canonical" href="<%= base_url %>/en/" />
+    <link rel="canonical" href="<%= root_url %>/en/" />
     <% locales.each do |locale| %>
     <link
       rel="alternate"
-      href="<%= base_url %>/<%= locale %>/"
+      href="<%= root_url %>/<%= locale %>/"
       hreflang="<%= locale %>" />
     <% end %>
     <%= erb("_favicon.html.erb") %>

--- a/src/html/main/surah-index.html.erb
+++ b/src/html/main/surah-index.html.erb
@@ -10,11 +10,11 @@
     <%= erb("_opengraph.html.erb", {file: "surah-index.html.erb", context:}) %>
     <link
       rel="canonical"
-      href="<%= base_url %>/<%= context.locale %>/"
+      href="<%= root_url %>/<%= context.locale %>/"
     />
     <% context.locales.each do |locale| %>
     <link rel="alternate"
-          href="<%= base_url %>/<%= locale %>/"
+          href="<%= root_url %>/<%= locale %>/"
           hreflang="<%= locale %>" />
     <% end %>
     <%= erb("_favicon.html.erb") %>

--- a/src/html/main/surah-stream.html.erb
+++ b/src/html/main/surah-stream.html.erb
@@ -30,7 +30,7 @@
     <%= erb("_postman.html.erb", {locale: context.locale, dir: context.dir}) %>
     <div class="app mount root w-full h-full"
          data-surah-id="<%= context.surah.id %>"
-         data-audio-base-url="<%= audio_base_url %>"
+         data-audio-url="<%= audio_url %>"
          data-commit-id="<%= commit %>">
     </div>
     <script src="/js/loaders/surah-stream-loader.js?v=<%= commit %>"></script>

--- a/src/html/main/surah-stream.html.erb
+++ b/src/html/main/surah-stream.html.erb
@@ -17,11 +17,11 @@
     <%= erb("_opengraph.html.erb", {file: "surah-stream.html.erb", context:}) %>
     <link
       rel="canonical"
-      href="<%= base_url %>/<%= context.locale %>/<%= context.surah.urlName %>/"
+      href="<%= root_url %>/<%= context.locale %>/<%= context.surah.urlName %>/"
     />
     <% context.locales.each do |locale| %>
     <link rel="alternate"
-          href="<%= base_url %>/<%= locale %>/<%= context.surah.urlName %>/"
+          href="<%= root_url %>/<%= locale %>/<%= context.surah.urlName %>/"
           hreflang="<%= locale %>" />
     <% end %>
     <%= erb("_favicon.html.erb") %>
@@ -29,9 +29,7 @@
   <body>
     <%= erb("_postman.html.erb", {locale: context.locale, dir: context.dir}) %>
     <div class="app mount root w-full h-full"
-         data-surah-id="<%= context.surah.id %>"
-         data-audio-url="<%= audio_url %>"
-         data-commit-id="<%= commit %>">
+         data-surah-id="<%= context.surah.id %>">
     </div>
     <script src="/js/loaders/surah-stream-loader.js?v=<%= commit %>"></script>
   </body>

--- a/src/js/components/AudioControl.tsx
+++ b/src/js/components/AudioControl.tsx
@@ -1,97 +1,42 @@
 import type { Surah, Ayah } from "Quran";
 import { SoundOnIcon, SoundOffIcon } from "~/components/Icon";
 
-export type TAudioStatus = "play" | "pause" | "wait" | "end";
+type Maybe<T> = T | null;
 
-type Maybe<T> = T | null | undefined;
-type TChangeFuncs = [() => void, () => void];
 type Props = {
   audio: HTMLAudioElement;
   surah: Surah;
   ayah: Maybe<Ayah>;
+  hidden: boolean;
   className?: string;
-  hidden?: boolean;
-  onStatusChange?: (s: TAudioStatus, fns: TChangeFuncs) => void;
 };
 
-export function AudioControl({
-  audio,
-  surah,
-  ayah,
-  className = "",
-  hidden = false,
-  onStatusChange = () => null,
-}: Props) {
-  const [enabled, setEnabled] = useState<boolean>(false);
-  const [audioStatus, setAudioStatus] = useState<Maybe<TAudioStatus>>(null);
-  const [audioBaseUrl, setAudioBaseUrl] = useState<Maybe<string>>(null);
-  const [commitId, setCommitId] = useState<Maybe<string>>(null);
-  const play = (audio: HTMLAudioElement) => audio.play().catch(() => null);
-  const pause = (audio: HTMLAudioElement) => audio.pause();
-
-  useEffect(() => {
-    if (hidden || !ayah || !audio || !audioBaseUrl) {
-      return;
-    }
-    if (enabled) {
-      audio.src = [audioBaseUrl, surah.id, `${ayah.id}.mp3?v=${commitId}`].join("/");
-      play(audio);
-    }
-  }, [hidden, enabled, ayah?.id, audioBaseUrl]);
-
-  useEffect(() => {
-    const el: HTMLDivElement | null = document.querySelector("[data-audio-base-url]");
-    const url = el?.dataset?.audioBaseUrl;
-    const commit = el?.dataset?.commitId;
-    if (url?.length) {
-      setAudioBaseUrl(url);
-      setCommitId(commit);
-    } else {
-      console.warn("audio.base_url is not set");
-    }
-  }, []);
-
-  useEffect(() => {
-    if (!audio || !ayah) {
-      return;
-    }
-    const onPlay = () => setAudioStatus("play");
-    const onPause = () => setAudioStatus("pause");
-    const onEnd = () => setAudioStatus("end");
-    const onWait = () => [setAudioStatus("wait"), play(audio)];
-    audio.addEventListener("play", onPlay);
-    audio.addEventListener("playing", onPlay);
-    audio.addEventListener("pause", onPause);
-    audio.addEventListener("ended", onEnd);
-    audio.addEventListener("stalled", onWait);
-    audio.addEventListener("waiting", onWait);
-    return () => {
-      audio.removeEventListener("play", onPlay);
-      audio.removeEventListener("playing", onPlay);
-      audio.removeEventListener("pause", onPause);
-      audio.removeEventListener("ended", onEnd);
-      audio.removeEventListener("stalled", onWait);
-      audio.removeEventListener("waiting", onWait);
-    };
-  }, [enabled, ayah?.id]);
-
-  useEffect(() => {
-    if (audioStatus) {
-      onStatusChange(audioStatus, [() => setEnabled(true), () => setEnabled(false)]);
-    }
-  }, [audioStatus]);
-
-  if (hidden) {
+export function AudioControl({ audio, surah, ayah, hidden, className }: Props) {
+  if (!ayah || !audio.el || hidden) {
     return null;
   }
 
+  useEffect(() => {
+    if (audio.isEnabled) {
+      audio.setSrc({ path: `/${surah.id}/${ayah.id}.mp3` });
+    }
+  }, [ayah.id, audio.isEnabled]);
+
+  useEffect(() => {
+    if (audio.isEnabled) {
+      audio.play();
+    } else {
+      audio.pause();
+    }
+  }, [ayah.id, audio.isEnabled]);
+
   return (
     <>
-      {enabled && (
-        <SoundOnIcon className={className} onClick={() => [setEnabled(false), pause(audio)]} />
+      {audio.isEnabled && (
+        <SoundOnIcon className={className} onClick={() => audio.disable()} />
       )}
-      {!enabled && (
-        <SoundOffIcon className={className} onClick={() => [setEnabled(true), play(audio)]} />
+      {!audio.isEnabled && (
+        <SoundOffIcon className={className} onClick={() => audio.enable()} />
       )}
     </>
   );

--- a/src/js/components/AudioControl.tsx
+++ b/src/js/components/AudioControl.tsx
@@ -20,11 +20,6 @@ export function AudioControl({ audio, surah, ayah, hidden, className }: Props) {
   useEffect(() => {
     if (audio.isEnabled) {
       audio.setSrc({ path: `/${surah.id}/${ayah.id}.mp3` });
-    }
-  }, [ayah.id, audio.isEnabled]);
-
-  useEffect(() => {
-    if (audio.isEnabled) {
       audio.play();
     } else {
       audio.pause();

--- a/src/js/components/AudioControl.tsx
+++ b/src/js/components/AudioControl.tsx
@@ -1,10 +1,11 @@
 import type { Surah, Ayah } from "Quran";
+import type { TAudio } from "~/hooks/useAudio";
 import { SoundOnIcon, SoundOffIcon } from "~/components/Icon";
 
 type Maybe<T> = T | null;
 
 type Props = {
-  audio: HTMLAudioElement;
+  audio: TAudio;
   surah: Surah;
   ayah: Maybe<Ayah>;
   hidden: boolean;

--- a/src/js/components/SurahStream/Stream.tsx
+++ b/src/js/components/SurahStream/Stream.tsx
@@ -1,4 +1,5 @@
 import type { Surah, Ayah, TAyat, TLocale } from "Quran";
+import { useAudio } from "~/hooks/useAudio";
 import { AudioControl } from "~/components/AudioControl";
 import { formatNumber, TFunction } from "~/lib/t";
 import classNames from "classnames";
@@ -16,6 +17,7 @@ export function Stream({ locale, surah, stream, endOfStream, isPaused, t }: Prop
   const className = endOfStream || isPaused ? ["scroll-y"] : [];
   const isRTL = locale.direction === "rtl";
   const ref = useRef<HTMLUListElement>(null);
+  const audio = useAudio();
   const ul = useMemo<JSX.Element>(() => {
     return (
       <ul
@@ -39,14 +41,9 @@ export function Stream({ locale, surah, stream, endOfStream, isPaused, t }: Prop
                 <AudioControl
                   className={classNames({ "mr-2": !isRTL, "ml-2": isRTL })}
                   hidden={!(isPaused || endOfStream)}
-                  audio={new Audio()}
+                  audio={audio}
                   surah={surah}
                   ayah={ayah}
-                  onStatusChange={(status, [, disable]) => {
-                    if (status === "end") {
-                      disable();
-                    }
-                  }}
                 />
                 <span className="color-primary font-semibold">
                   {t(locale, "surah")} {formatNumber(locale, surah.id)}
@@ -66,7 +63,7 @@ export function Stream({ locale, surah, stream, endOfStream, isPaused, t }: Prop
         })}
       </ul>
     );
-  }, [stream.length, isPaused, endOfStream]);
+  }, [stream.length, audio.isEnabled, isPaused, endOfStream]);
 
   useEffect(() => {
     const el = ref.current;
@@ -75,6 +72,12 @@ export function Stream({ locale, surah, stream, endOfStream, isPaused, t }: Prop
       el.scrollTo({ behavior: "smooth", top });
     }
   }, [stream.length]);
+
+  useEffect(() => {
+    if (audio.isEnded) {
+      audio.disable();
+    }
+  }, [audio.isEnded]);
 
   return ul;
 }

--- a/src/js/components/Timer/index.tsx
+++ b/src/js/components/Timer/index.tsx
@@ -1,4 +1,5 @@
 import type { Surah, Ayah, TLocale } from "Quran";
+import type { TAudio } from "~/hooks/useAudio";
 import { formatNumber } from "~/lib/t";
 
 type Maybe<T> = T | null | undefined;
@@ -8,7 +9,7 @@ type Props = {
   surah: Surah;
   ayah: Maybe<Ayah>;
   isPaused: boolean;
-  audio: HTMLAudioElement;
+  audio: TAudio;
   onComplete: (surah: Surah, ayah: Ayah) => void;
 };
 
@@ -25,7 +26,7 @@ export function Timer({ locale, surah, ayah, isPaused, audio, onComplete }: Prop
       return audio.el.duration * 1000;
     } else {
       console.info("Timer.tsx", "getMS", "ayah.ms provides duration");
-      return ayah.ms;
+      return ayah?.ms || 0;
     }
   }
 

--- a/src/js/components/Timer/index.tsx
+++ b/src/js/components/Timer/index.tsx
@@ -19,7 +19,7 @@ export function Timer({ locale, surah, ayah, isPaused, audio, onComplete }: Prop
   function getMs() {
     if (audio.isEnabled) {
       if (audio.isPlaying) {
-        return (ms || audio.el.duration * 1000);
+        return ms || audio.el.duration * 1000;
       } else if (audio.isPaused) {
         return ms;
       } else {
@@ -55,8 +55,9 @@ export function Timer({ locale, surah, ayah, isPaused, audio, onComplete }: Prop
       return;
     } else {
       const tid = setTimeout(() => {
-        if (ms > 0) {
-          setMs(ms - 250);
+        const nms = Number(ms);
+        if (nms > 0) {
+          setMs(nms - 250);
         } else if (ayah) {
           onComplete(surah, ayah);
         }

--- a/src/js/hooks/useAudio.ts
+++ b/src/js/hooks/useAudio.ts
@@ -32,12 +32,18 @@ export function useAudio(): TAudio {
   const [state, setState] = useState<AudioStateKey>(AudioState.Waiting);
 
   const showStalledIcon = useMemo(() => {
-    if (state === AudioState.Waiting) {
-      return el.currentTime > 0;
+    if (enabled) {
+      if (el.readyState < 2) {
+        return true;
+      } else if (state === AudioState.Waiting) {
+        return el.currentTime > 0;
+      } else {
+        return state === AudioState.Stalled;
+      }
     } else {
-      return state === AudioState.Stalled;
+      return false;
     }
-  }, [state]);
+  }, [enabled, el.readyState, state]);
 
   useEffect(() => {
     const onPause = () => setState(AudioState.Paused);

--- a/src/js/hooks/useAudio.ts
+++ b/src/js/hooks/useAudio.ts
@@ -1,3 +1,20 @@
+export type TAudio = {
+  el: HTMLAudioElement;
+  isEnabled: boolean;
+  isPlaying: boolean;
+  isPaused: boolean;
+  isWaiting: boolean;
+  isStalled: boolean;
+  isEnded: boolean;
+  hasError: boolean;
+  showStalledIcon: boolean;
+  enable: () => void;
+  disable: () => void;
+  pause: () => void;
+  play: () => void;
+  setSrc: ({ path }: { path: string }) => void;
+};
+
 enum AudioState {
   Playing = "Playing",
   Paused = "Paused",
@@ -9,7 +26,7 @@ enum AudioState {
 
 type AudioStateKey = keyof typeof AudioState;
 
-export function useAudio() {
+export function useAudio(): TAudio {
   const el = useMemo(() => new Audio(), []);
   const [enabled, setEnabled] = useState<boolean>(false);
   const [state, setState] = useState<AudioStateKey>(AudioState.Waiting);

--- a/src/js/hooks/useAudio.ts
+++ b/src/js/hooks/useAudio.ts
@@ -1,0 +1,89 @@
+enum AudioState {
+  Playing = "Playing",
+  Paused = "Paused",
+  Waiting = "Waiting",
+  Stalled = "Stalled",
+  Ended = "Ended",
+  Error = "Error",
+}
+
+type AudioStateKey = keyof typeof AudioState;
+
+type TData = {
+  commitId: string;
+  audioUrl: string;
+};
+
+export function useAudio() {
+  const el = useMemo(() => new Audio(), []);
+  const [enabled, setEnabled] = useState<boolean>(false);
+  const [state, setState] = useState<AudioStateKey>(AudioState.Waiting);
+  const [data, setData] = useState<TData | null>(null);
+
+  const showStalledIcon = useMemo(() => {
+    if (state === AudioState.Waiting) {
+      return el.currentTime > 0;
+    } else {
+      return state === AudioState.Stalled;
+    }
+  }, [state]);
+
+  useEffect(() => {
+    const onPause = () => setState(AudioState.Paused);
+    const onWait = () => setState(AudioState.Waiting);
+    const onStall = () => setState(AudioState.Stalled);
+    const onResume = () => setState(AudioState.Playing);
+    const onError = () => setState(AudioState.Error);
+    const onEnded = () => setState(AudioState.Ended);
+    el.addEventListener("pause", onPause);
+    el.addEventListener("waiting", onWait);
+    el.addEventListener("stalled", onStall);
+    el.addEventListener("playing", onResume);
+    el.addEventListener("ended", onEnded);
+    el.addEventListener("error", onError);
+    return () => {
+      el.removeEventListener("pause", onPause);
+      el.removeEventListener("waiting", onWait);
+      el.removeEventListener("stalled", onStall);
+      el.removeEventListener("playing", onResume);
+      el.removeEventListener("ended", onEnded);
+      el.removeEventListener("error", onError);
+    };
+  }, [el.src]);
+
+  useEffect(() => {
+    const el: HTMLDivElement = document.querySelector(".app")!;
+    const set = el.dataset;
+    setData({
+      audioUrl: set.audioUrl,
+      commitId: set.commitId,
+    });
+  }, []);
+
+  return {
+    el,
+    isEnabled: enabled,
+    isPlaying: state === AudioState.Playing,
+    isPaused: state === AudioState.Paused,
+    isWaiting: state === AudioState.Waiting,
+    isStalled: state === AudioState.Stalled,
+    isEnded: state === AudioState.Ended,
+    hasError: state === AudioState.Error,
+    showStalledIcon,
+    enable() {
+      setEnabled(true);
+    },
+    disable() {
+      setEnabled(false);
+    },
+    pause() {
+      el.pause();
+    },
+    play() {
+      el.play();
+    },
+    setSrc({ path }: { path: string }) {
+      el.src = [data.audioUrl, path, `?v=${data.commitId}`].join("");
+    },
+  };
+}

--- a/src/js/hooks/useAudio.ts
+++ b/src/js/hooks/useAudio.ts
@@ -9,16 +9,10 @@ enum AudioState {
 
 type AudioStateKey = keyof typeof AudioState;
 
-type TData = {
-  commitId: string;
-  audioUrl: string;
-};
-
 export function useAudio() {
   const el = useMemo(() => new Audio(), []);
   const [enabled, setEnabled] = useState<boolean>(false);
   const [state, setState] = useState<AudioStateKey>(AudioState.Waiting);
-  const [data, setData] = useState<TData | null>(null);
 
   const showStalledIcon = useMemo(() => {
     if (state === AudioState.Waiting) {
@@ -51,15 +45,6 @@ export function useAudio() {
     };
   }, [el.src]);
 
-  useEffect(() => {
-    const el: HTMLDivElement = document.querySelector(".app")!;
-    const set = el.dataset;
-    setData({
-      audioUrl: set.audioUrl,
-      commitId: set.commitId,
-    });
-  }, []);
-
   return {
     el,
     isEnabled: enabled,
@@ -83,7 +68,7 @@ export function useAudio() {
       el.play();
     },
     setSrc({ path }: { path: string }) {
-      el.src = [data.audioUrl, path, `?v=${data.commitId}`].join("");
+      el.src = [audioUrl, path, `?v=${commitId}`].join("");
     },
   };
 }

--- a/src/js/types/globals.d.ts
+++ b/src/js/types/globals.d.ts
@@ -10,4 +10,6 @@ declare global {
   const useMemo: typeof hooks.useMemo;
   const createRef: typeof preact.createRef;
   const classNames: typeof classn;
+  const audioUrl: string;
+  const commitId: string;
 }

--- a/src/sitemap.xml.erb
+++ b/src/sitemap.xml.erb
@@ -3,19 +3,19 @@
         xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <% locales.each do |locale| %>
   <url>
-    <loc><%= base_url %>/<%= locale %>/</loc>
+    <loc><%= root_url %>/<%= locale %>/</loc>
     <priority>1.0</priority>
     <changefreq>weekly</changefreq>
   </url>
   <% Ryo.each(name_by_id) do |_id, name| %>
   <url>
-    <loc><%= base_url %>/<%= locale %>/<%= name %>/</loc>
+    <loc><%= root_url %>/<%= locale %>/<%= name %>/</loc>
     <priority>0.9</priority>
     <changefreq>weekly</changefreq>
   </url>
   <% end %>
   <url>
-    <loc><%= base_url %>/<%= locale %>/random/</loc>
+    <loc><%= root_url %>/<%= locale %>/random/</loc>
     <priority>0.8</priority>
     <changefreq>weekly</changefreq>
   </url>


### PR DESCRIPTION
* [audio: import & improve useAudio (via EasyQuran)](https://github.com/ReflectsLight/al-quran.reflectslight.io/commit/fe96910ca0c29a3811945afa0675079eda570fdd)
The basis for this code comes from EasyQuran, and it has
been improved and modified in the process. The 'useAudio'
hook now returns an abstraction built around HTMLAudioElement.<br>
Rather than having many disconnected states, the abstraction
encapsulates everything to do with an audio element in a single
object and sets the stage for more refactors in the future -
Inshallah.

* [audio: fixes for mobile, and other improvements](https://github.com/ReflectsLight/al-quran.reflectslight.io/pull/154/commits/51dc9bfff10318d5fb63f403ee4177c333b40a50)
This change fixes buggy behavior on mobile (tested on iOS), and it
also synchronizes the play|pause icons to the playback of audio as
well. Previously, you could pause the stream and the audio would
continue playing regardless. With this change, the audio is paused
and it can also be resumed from the point of pause. The timer also
picks up from where it left off.

* [Add globals](https://github.com/ReflectsLight/al-quran.reflectslight.io/commit/dc96a8c875148d1fb154ca8d30d3c0c57495fbca)
The globals audioUrl and commitId replace variables that
were previously pulled from the DOM on the fly. This is
another improvement inspired by the EasyQuran project. <br>
A slight rename is also included in this change. We've moved
away from "base url" and towards "root url" instead